### PR TITLE
git-crypt: relocate unlock code

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: install git-related software
+- name: Install git-related software
   become: true
   ansible.builtin.apt:
     name: "{{ packages }}"
@@ -12,6 +12,18 @@
       - git-lfs
       - pre-commit
       - git-crypt
+
+- name: Ensure secrets are decrypted
+  ansible.builtin.command:
+    cmd: git crypt unlock
+    chdir: "{{ role_path }}/../.."
+  register: git_crypt_unlock
+  # always changed
+  changed_when: true
+  # allow me to work on the repo and run the playbook without this failing
+  failed_when: >
+    git_crypt_unlock.rc != 0 and
+    "Please commit your changes or 'git stash' them before running 'git-crypt unlock'." not in git_crypt_unlock.stderr
 
 # see https://github.com/getsops/sops
 # releases from https://github.com/getsops/sops/releases

--- a/roles/spryker/tasks/vpn.yaml
+++ b/roles/spryker/tasks/vpn.yaml
@@ -13,26 +13,6 @@
     state: directory
     mode: "0755"
 
-- name: Check if secrets are decrypted
-  ansible.builtin.command:
-    cmd: git crypt status
-    chdir: "{{ role_path }}/../.."
-  register: git_crypt_status
-  # never changed, otherwise is always changed
-  changed_when: false
-
-- name: Ensure secrets are decrypted
-  ansible.builtin.command:
-    cmd: git crypt unlock
-    chdir: "{{ role_path }}/../.."
-  # always changed if run
-  changed_when: true
-  when: >
-    "not encrypted: roles/spryker/secrets/spryker-vpn-ca.pem" in git_crypt_status.stdout or
-    "not encrypted: roles/spryker/secrets/spryker-vpn-cert.pem" in git_crypt_status.stdout or
-    "not encrypted: roles/spryker/secrets/spryker-vpn-key.pem" in git_crypt_status.stdout or
-    "not encrypted: roles/spryker/secrets/spryker-vpn-tls-auth.pem" in git_crypt_status.stdout
-
 - name: Ensure secrets exists
   ansible.builtin.copy:
     src: "{{ item }}"


### PR DESCRIPTION
To make it more generic, and at the begining of the playbook.